### PR TITLE
Add test coverage report generation

### DIFF
--- a/.github/workflows/pull-request-ci.yml
+++ b/.github/workflows/pull-request-ci.yml
@@ -28,7 +28,7 @@ jobs:
       - run: npm run lint:fix
       # Run unit tests
       - run: npm run test
-      # Run unit tests
+      # Run unit tests with coverage
       - run: npm run coverage
       # Run build
       - run: npm run build

--- a/.github/workflows/pull-request-ci.yml
+++ b/.github/workflows/pull-request-ci.yml
@@ -28,5 +28,7 @@ jobs:
       - run: npm run lint:fix
       # Run unit tests
       - run: npm run test
+      # Run unit tests
+      - run: npm run coverage
       # Run build
       - run: npm run build

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,8 @@
+# Node.js dependencies
 /node_modules/
+
+# TypeScript transpiled JS 
 /dist/
+
+# Jest coverage report
+/coverage/

--- a/package.json
+++ b/package.json
@@ -5,14 +5,41 @@
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "scripts": {
-    "test": "jest",
     "build": "tsc",
     "lint": "eslint ./src ./test --ext .ts",
-    "lint:fix": "eslint ./src ./test --ext .ts --fix"
+    "lint:fix": "eslint ./src ./test --ext .ts --fix",
+    "coverage": "ts-node test --coverage --silent",
+    "test": "ts-node test"
   },
   "jest": {
+    "collectCoverageFrom": [
+      "src/lib/**/*.ts",
+      "src/util/Util.ts"
+    ],
+    "coveragePathIgnorePatterns": [
+      "<rootDir>/node_modules"
+    ],
+    "coverageReporters": [
+      "json",
+      "lcov",
+      "text"
+    ],
+    "coverageThreshold": {
+      "global": {
+        "branches": 80,
+        "functions": 80,
+        "lines": 80,
+        "statements": 80
+      }
+    },
     "preset": "ts-jest",
-    "testEnvironment": "node"
+    "testEnvironment": "node",
+    "testRegex": "(/__tests__/.*|\\.(test|spec))\\.(ts)$",
+    "moduleFileExtensions": [
+      "ts",
+      "js",
+      "json"
+    ]
   },
   "files": [
     "dist/**/*"

--- a/src/lib/distance/__test__/distance.test.ts
+++ b/src/lib/distance/__test__/distance.test.ts
@@ -46,10 +46,10 @@ describe('Unit tests for the distance library', () => {
       },
     };
 
-    validElements.forEach(([elmA, elmB]) => {
+    for (const [elmA, elmB] of validElements) {
       const parsedElements = parseElementCoords(elmA, elmB);
       expect(parsedElements).toStrictEqual(expected);
-    });
+    }
   });
 
   it('tries to parse incomplete or mixed GPS elements', () => {
@@ -87,14 +87,13 @@ describe('Unit tests for the distance library', () => {
       },
     ];
 
-    testCases.forEach((testCase) => {
+    for (const testCase of testCases) {
       const {
         elements: [elmA, elmB],
         expected,
       } = testCase;
       const parsedElements = parseElementCoords(elmA, elmB);
-
       expect(parsedElements).toStrictEqual(expected);
-    });
+    }
   });
 });

--- a/src/util/__test__/Util.test.ts
+++ b/src/util/__test__/Util.test.ts
@@ -35,10 +35,10 @@ describe('Unit tests of the utility module', () => {
     it(`evaluates the distance with different types of GPS elements for the ${algorithm.toUpperCase()} method`, () => {
       const { expectedValue } = distanceAlgTestCases[algorithm];
 
-      validElements.forEach(([elmA, elmB]) => {
+      for (const [elmA, elmB] of validElements) {
         const distance = Util.elementDistance(elmA, elmB, algorithm as DistanceAlgorithms);
         expect(distance).toBeLessThanOrEqual(expectedValue);
-      });
+      }
     });
 
     it(`tries to evaluate distance with an incomplete GPS element for the ${algorithm.toUpperCase()} method`, () => {
@@ -52,9 +52,9 @@ describe('Unit tests of the utility module', () => {
         [{ lat: '35.6544' }, { longitude: 39.8261 }],
       ];
 
-      invalidElements.forEach(([elmA, elmB]) => {
+      for (const [elmA, elmB] of invalidElements) {
         expect(Util.elementDistance(elmA, elmB, algorithm as DistanceAlgorithms)).toBeUndefined();
-      });
+      }
     });
   }
 });

--- a/test/index.ts
+++ b/test/index.ts
@@ -1,117 +1,137 @@
-import Logger from '../src/util/Logger';
+import * as jest from 'jest';
 
-const logger = Logger(__filename);
+// Do this as the first thing so that any code reading it knows the right env.
+process.env.NODE_ENV = 'test';
 
-import OZMapSDK from '../src/OZMapSDK';
+// Makes the script crash on unhandled rejections instead of silently
+// ignoring them. In the future, promise rejections that are not handled will
+// terminate the Node.js process with a non-zero exit code.
+process.on('unhandledRejection', (err) => {
+  throw err;
+});
 
-(async function () {
-  logger.info('Iniciando os testes!');
-  const ozmap = new OZMapSDK('********************');
-  await ozmap.authentication('**********', '****************');
+const argv = process.argv.slice(2);
 
-  // if (ozmap.isConnected()) {
-  //   try {
-  //     await ozmap
-  //       .getUser()
-  //       .update({
-  //         id: new ObjectID('60d0f62380067800241eb202'),
-  //         password: '12345678',
-  //       });
-  //   } catch (e) {
-  //     console.log(e);
-  //   }
+// Watch unless on CI or in coverage mode
+if (!process.env.CI && argv.indexOf('--coverage') < 0) {
+  argv.push('--watchAll');
+}
 
-  // if (ozmap.isConnected()) {
-  //     try {
-  //         await ozmap
-  //             .getUser().getAll()
-  //     } catch (e) {
-  //         console.log(e);
-  //     }
+jest.run(argv);
 
-  // if (ozmap.isConnected()) {
-  //     try {
-  //         await ozmap
-  //             .getClient()
-  //             .update({
-  //                 id: new ObjectID('5da76c5111450e000694908c'),
-  //                 onu: {
-  //                     user_PPPoE: '12345678 - Atualizado 3006',
-  //                     serial_number: '123456712345678 - Atualizado 3006',
-  //                     mac_address: '1234567812345678 - Atualizado 3006'
-  //                 }
-  //             });
-  //     } catch (e) {
-  //         console.log(e);
-  //     }
+// import Logger from '../src/util/Logger';
 
-  // if (ozmap.isConnected()) {
-  //     try {
-  //         const client = await ozmap
-  //             .getClient().getOneByONUCode("12345678 - Atualizado - Via Node-red")
-  //         console.log(client)
-  //     } catch (e) {
-  //         console.log(e);
-  //     }
-  //
-  // }
-  // let clonedProject = await ozmap.getProject().clone(new ObjectID("60cf83e7286cb60018458741"));
+// const logger = Logger(__filename);
 
-  // console.log(clonedProject)
+// import OZMapSDK from '../src/OZMapSDK';
 
-  // ozmap.getUser().addProject(
-  // 	new ObjectID("60cf534380067800241ea9fd"),
-  // 	new ObjectID("40ccee1480067800241ea51e"),
-  // 	new ObjectID("4accf8ee0ff2c819a4ffd38e")
-  // )
+// (async function () {
+//   logger.info('Iniciando os testes!');
+//   const ozmap = new OZMapSDK('********************');
+//   await ozmap.authentication('**********', '****************');
 
-  // if (ozmap.isConnected()) {
-  //     try {
-  //         const allProperties = await ozmap
-  //             .getProperty().getAll()
-  //
-  //         // console.log(allProperties.rows[0].client.id)
-  //
-  //         const singlePropertie = await ozmap.getProperty().getPropertyByClientId("5da62434493d9c00066655fe")
-  //
-  //         const objToUpdate = {
-  //             id: singlePropertie.rows[0].id.toString(),
-  //             address:"Atualizado"
-  //         }
-  //
-  //         console.log(singlePropertie)
-  //
-  //         // await ozmap.getProperty().update(objToUpdate)
-  //     } catch (e) {
-  //         console.log(e);
-  //     }
-  // }
+// if (ozmap.isConnected()) {
+//   try {
+//     await ozmap
+//       .getUser()
+//       .update({
+//         id: new ObjectID('60d0f62380067800241eb202'),
+//         password: '12345678',
+//       });
+//   } catch (e) {
+//     console.log(e);
+//   }
 
-  if (ozmap.isConnected()) {
-    try {
-      const allClientsData = await ozmap.getProperty().getAllByQuery({ select: 'client', limit: 20 });
-      logger.info(allClientsData);
-    } catch (e) {
-      logger.error(e);
-    }
-  }
-  /**
-     const user = await ozmap.getUser().getByUsername("1raupp");
-     console.log(user);
+// if (ozmap.isConnected()) {
+//     try {
+//         await ozmap
+//             .getUser().getAll()
+//     } catch (e) {
+//         console.log(e);
+//     }
 
-     const projectByUsername = await ozmap.getUser().getAllProjects(user.id)
-     console.log("PROJECTS BY USERNAME: ",user, projectByUsername)
+// if (ozmap.isConnected()) {
+//     try {
+//         await ozmap
+//             .getClient()
+//             .update({
+//                 id: new ObjectID('5da76c5111450e000694908c'),
+//                 onu: {
+//                     user_PPPoE: '12345678 - Atualizado 3006',
+//                     serial_number: '123456712345678 - Atualizado 3006',
+//                     mac_address: '1234567812345678 - Atualizado 3006'
+//                 }
+//             });
+//     } catch (e) {
+//         console.log(e);
+//     }
 
-     const userToFindByUsername = await ozmap.getUser().getByUsername('admin')
-     console.log("GET USER BY USERNAME: ", userToFindByUsername)
+// if (ozmap.isConnected()) {
+//     try {
+//         const client = await ozmap
+//             .getClient().getOneByONUCode("12345678 - Atualizado - Via Node-red")
+//         console.log(client)
+//     } catch (e) {
+//         console.log(e);
+//     }
 
-     const userToFindByEmail = await ozmap.getUser().getByEmail("contato@devoz.com.br")
-     console.log("GET USER BY EMAIL: ", userToFindByEmail)
-     **/
+// }
+// let clonedProject = await ozmap.getProject().clone(new ObjectID("60cf83e7286cb60018458741"));
 
-  //const userToFindByUsername = await ozmap.getUser().getByUsername('1raupp')
+// console.log(clonedProject)
 
-  //let allprojects = await ozmap.getProject().getAll()//getUser().getAllProjects(userToFindByUsername.id);
-  //console.log("GET USER BY USERNAME: ", allprojects)
-  // }
-})();
+// ozmap.getUser().addProject(
+// 	new ObjectID("60cf534380067800241ea9fd"),
+// 	new ObjectID("40ccee1480067800241ea51e"),
+// 	new ObjectID("4accf8ee0ff2c819a4ffd38e")
+// )
+
+// if (ozmap.isConnected()) {
+//     try {
+//         const allProperties = await ozmap
+//             .getProperty().getAll()
+
+//         // console.log(allProperties.rows[0].client.id)
+
+//         const singlePropertie = await ozmap.getProperty().getPropertyByClientId("5da62434493d9c00066655fe")
+
+//         const objToUpdate = {
+//             id: singlePropertie.rows[0].id.toString(),
+//             address:"Atualizado"
+//         }
+
+//         console.log(singlePropertie)
+
+//         // await ozmap.getProperty().update(objToUpdate)
+//     } catch (e) {
+//         console.log(e);
+//     }
+// }
+
+// if (ozmap.isConnected()) {
+//   try {
+//     const allClientsData = await ozmap.getProperty().getAllByQuery({ select: 'client', limit: 20 });
+//     logger.info(allClientsData);
+//   } catch (e) {
+//     logger.error(e);
+//   }
+// }
+
+//  const user = await ozmap.getUser().getByUsername("1raupp");
+//  console.log(user);
+
+//  const projectByUsername = await ozmap.getUser().getAllProjects(user.id)
+//  console.log("PROJECTS BY USERNAME: ",user, projectByUsername)
+
+//  const userToFindByUsername = await ozmap.getUser().getByUsername('admin')
+//  console.log("GET USER BY USERNAME: ", userToFindByUsername)
+
+//  const userToFindByEmail = await ozmap.getUser().getByEmail("contato@devoz.com.br")
+//  console.log("GET USER BY EMAIL: ", userToFindByEmail)
+
+// const userToFindByUsername = await ozmap.getUser().getByUsername('1raupp')
+
+// let allprojects = await ozmap.getProject().getAll()//getUser().getAllProjects(userToFindByUsername.id);
+// console.log("GET USER BY USERNAME: ", allprojects)
+// }
+// })();


### PR DESCRIPTION
Nesse PR foi implementado o mecanismo de aferição de cobertura de código por testes unitários.

* Foi implementado o script `test/index.ts`, o qual executa o Jest condicionado ao valor de algumas variáveis de ambiente e argumentos;
* No `package.json`, foram incluídas configurações adicionais à execução do Jest:
  * Incluído o script `npm run coverage`, o qual gera o relatório de cobertura dos testes. Nesse momento, as porcentagens mínimas aceitáveis de cobertura foram setadas em 80%;
  * Atualizadas configurações de limitação de análise de cobertura de código por testes na chave `"jest"`. Por hora, os arquivos analisados estão em `src/lib` e `src/util`, como é ilustrado no resultado abaixo:
![image](https://user-images.githubusercontent.com/35070513/140199833-38029a5d-b025-445b-90d4-80383e6efa8e.png)
  * Incluida a aferição de cobertura na pipeline em `pull-request-ci.yml`;


