### PR TITLE
Logging improvements, paginated searches with queries in properties and clients

### DIFF
--- a/src/OZMapSDK.ts
+++ b/src/OZMapSDK.ts
@@ -29,9 +29,9 @@ class OZMapSDK {
   private prospect: Prospect;
   private building: Building;
 
-  constructor(url: string, key?: string) {
+  constructor(url: string, key?: string, authenticate = true) {
     logger.debug('OZMapSDK created');
-    this.restapi = new RESTAPI(url, key);
+    this.restapi = new RESTAPI(url, key, authenticate);
     this.box = new Box(this.restapi, this);
     this.project = new Project(this.restapi, this);
     this.user = new User(this.restapi, this);

--- a/src/OZMapSDK.ts
+++ b/src/OZMapSDK.ts
@@ -14,6 +14,7 @@ import NetworkConnectable from './proxy/NetworkConnectable';
 import Region from './proxy/Region';
 import Prospect from './proxy/Prospect';
 import Building from './proxy/Building';
+import winston = require('winston');
 
 class OZMapSDK {
   private restapi: RESTAPI;
@@ -99,6 +100,10 @@ class OZMapSDK {
 
   getBuilding(): Building {
     return this.building;
+  }
+
+  getLogger(): winston.Logger {
+    return logger;
   }
 }
 

--- a/src/interface/IFilter.ts
+++ b/src/interface/IFilter.ts
@@ -4,5 +4,5 @@ import ObjectID from 'bson-objectid';
 export default interface IFilter {
   property: string;
   operator: EnumOperator;
-  value: string | Array<string> | Array<ObjectID> | ObjectID;
+  value: string | Array<string> | Array<ObjectID> | ObjectID | null;
 }

--- a/src/proxy/Base.ts
+++ b/src/proxy/Base.ts
@@ -87,6 +87,11 @@ abstract class Base {
 
   protected getAllByQueryHelper<T extends IModel>(readQueryInput: IReadQueryInput): Promise<IPagination<T>> {
     readQueryInput.model = this.endpoint;
+    return this.restapi.read<T>(readQueryInput);
+  }
+
+  protected getAllPaginatedByQueryHelper<T extends IModel>(readQueryInput: IReadQueryInput): Promise<IPagination<T>> {
+    readQueryInput.model = this.endpoint;
     return this.restapi.fetchAllWithPagination<T>(readQueryInput);
   }
 

--- a/src/proxy/Base.ts
+++ b/src/proxy/Base.ts
@@ -10,6 +10,7 @@ import OZMapSDK from '../OZMapSDK';
 import { EnumOperator } from '../interface/EnumOperator';
 import ObjectID from 'bson-objectid';
 import IReadQueryInput from '../interface/IReadQueryInput';
+import request = require('superagent');
 
 abstract class Base {
   protected abstract endpoint: string;
@@ -105,6 +106,14 @@ abstract class Base {
       filter: [{ property: 'id', operator: EnumOperator.IN, value: ids }],
     });
     return paginatedModels.rows;
+  }
+
+  protected async batchUpdateHelper(filter: IFilter[], update: IModel): Promise<request.Response> {
+    const update_model = this.endpoint;
+    const v2_route = `${update_model}/batch-update`;
+    const data = { update };
+    const query = { filter };
+    return await this.restapi.customRequest('POST', v2_route, query, data);
   }
 }
 

--- a/src/proxy/Base.ts
+++ b/src/proxy/Base.ts
@@ -87,7 +87,7 @@ abstract class Base {
 
   protected getAllByQueryHelper<T extends IModel>(readQueryInput: IReadQueryInput): Promise<IPagination<T>> {
     readQueryInput.model = this.endpoint;
-    return this.restapi.read<T>(readQueryInput);
+    return this.restapi.fetchAllWithPagination<T>(readQueryInput);
   }
 
   protected byIdHelper<T extends IModel>(id: ObjectID | IModel): Promise<T> {

--- a/src/proxy/Client.ts
+++ b/src/proxy/Client.ts
@@ -5,6 +5,7 @@ import IFilter from '../interface/IFilter';
 import ObjectID from 'bson-objectid';
 import { EnumOperator } from '../interface/EnumOperator';
 import IReadQueryInput from '../interface/IReadQueryInput';
+import request = require('superagent');
 
 class Client extends Base {
   protected endpoint = 'ftth-clients';
@@ -27,6 +28,10 @@ class Client extends Base {
 
   update(model: IClient): Promise<void> {
     return this.updateHelper(model);
+  }
+
+  batchUpdate(filter: Array<IFilter>, update: Record<string, unknown>): Promise<request.Response> {
+    return this.batchUpdateHelper(filter, update);
   }
 
   getAllByFilter(filter: Array<IFilter>): Promise<IPagination<IClient>> {

--- a/src/proxy/Client.ts
+++ b/src/proxy/Client.ts
@@ -58,6 +58,10 @@ class Client extends Base {
   getAllByQuery(readQueryInput: IReadQueryInput): Promise<IPagination<IClient>> {
     return this.getAllByQueryHelper<IClient>(readQueryInput);
   }
+
+  getAllPaginatedByQuery(readQueryInput: IReadQueryInput): Promise<IPagination<IClient>> {
+    return this.getAllPaginatedByQueryHelper<IClient>(readQueryInput);
+  }
 }
 
 export default Client;

--- a/src/proxy/Property.ts
+++ b/src/proxy/Property.ts
@@ -42,6 +42,10 @@ class Property extends Base {
     return this.getAllByQueryHelper<IProperty>(readQueryInput);
   }
 
+  getAllPaginatedByQuery(readQueryInput: IReadQueryInput): Promise<IPagination<IProperty>> {
+    return this.getAllPaginatedByQueryHelper<IProperty>(readQueryInput);
+  }
+
   getByIds(ids: Array<ObjectID>): Promise<Array<IProperty>> {
     return this.byIdsHelper<IProperty>(ids);
   }

--- a/src/proxy/Property.ts
+++ b/src/proxy/Property.ts
@@ -5,6 +5,7 @@ import IFilter from '../interface/IFilter';
 import ObjectID from 'bson-objectid';
 import { EnumOperator } from '../interface/EnumOperator';
 import IReadQueryInput from '../interface/IReadQueryInput';
+import request = require('superagent');
 
 class Property extends Base {
   protected endpoint = 'properties';
@@ -27,6 +28,10 @@ class Property extends Base {
 
   update(model: IProperty): Promise<void> {
     return this.updateHelper(model);
+  }
+
+  batchUpdate(filter: Array<IFilter>, update: Record<string, unknown>): Promise<request.Response> {
+    return this.batchUpdateHelper(filter, update);
   }
 
   getAllByFilter(filter: Array<IFilter>): Promise<IPagination<IProperty>> {

--- a/src/util/RESTAPI.ts
+++ b/src/util/RESTAPI.ts
@@ -16,11 +16,11 @@ class RESTAPI {
   readonly url: string;
   private key?: string;
 
-  constructor(url: string, key?: string) {
+  constructor(url: string, key?: string, authenticate = true) {
     this.url = url;
     this.key = key;
     this.connected = false;
-    if (key) {
+    if (key && authenticate) {
       this.authentication();
     }
   }


### PR DESCRIPTION
- WiP (Work in Progress)?
  - Não.

- Qual o problema/feature?
  - As funcionalidades atuais do pacote não atendiam as demandas da integração SmartOLT nova.

- O que foi feito?
  - Novas funcionalidades para clientes e propriedades:
    - Adicionado batch-update para clientes e propriedades.
    - Adicionado um método para buscas com query paginadas para clientes e propriedades.
  - Modificações nos logs: 
    - Adicionado logs para as chamadas API do módulo RESTAPI
    - Adicionada uma forma de logging nova específica para a integração, forma agora que é decidida pela ENV 'NODE_ENV'
    - Adicionado uma ENV LOG_LEVEL, que é específica para logs e é verificada antes de qualquer outras condições
    - Modificado o método em que novos logs são gerados para logger.child, para poder modificar os transportes de todos os logs modificando o transporte do log parente
    - Melhorias nos logs de autenticação
  - Feito a autenticação automática do construtor do OZSDK ser opcional, para que scripts usando a classe só tenham a autenticação chamada quando necessário
  - Adicionado um novo tipo de variável para a interface IFilter, null, para buscas onde isso é relevante ('client not equals null' para propriedades por exemplo).

- Como testar?
  - Instanciando o pacote devidamente: 
    - Faça uma busca utilizando getAllPaginatedByQuery nos clientes e propriedades e cheque se o retorno está correto de acordo com os filtros.
    - Com a ENV LOG_LEVEL setada para níveis diversos (silly, warn, etc) e NODE_ENV setada para integration ou development, checar se os logs fazem sentido com os formatos de logs utilizados (lembrando que NODE_ENV cuida tanto de nível de logs (sendo ausente a ENV LOG_LEVEL) como o formato, 'integration' sendo usando o novo formato).