### PR TITLE
Fix for batch-update not utilizing filters sent correctly

### DIFF
--- a/src/proxy/Base.ts
+++ b/src/proxy/Base.ts
@@ -116,9 +116,8 @@ abstract class Base {
   protected async batchUpdateHelper(filter: IFilter[], update: IModel): Promise<request.Response> {
     const update_model = this.endpoint;
     const v2_route = `${update_model}/batch-update`;
-    const data = { update };
-    const query = { filter };
-    return await this.restapi.customRequest('POST', v2_route, query, data);
+    const data = { update, filter };
+    return await this.restapi.customRequest('POST', v2_route, undefined, data);
   }
 }
 


### PR DESCRIPTION
- WiP (Work in Progress)?
  - Não.

- Qual o problema/feature?
  - O batch-update não estava utilizando os filtros enviados corretamente, atualizando todos os elementos ao invés de só os requeridos.

- O que foi feito?
  - Adicionados os filtros ao body enviado pela requisição feita no batchUpdateHelper.

- Como testar?
  - Instanciando o pacote devidamente: 
    - Faça updates em batch de diversos clientes/propriedades.